### PR TITLE
Use parse2 instead of parse

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,46 @@
+use std::path::Path;
+use wallet_pass::{
+    template::{Barcode, BarcodeFormat, Details, Field},
+    Pass,
+};
+
+fn main() {
+    // Load pass template
+    let mut pass = Pass::from_path(Path::new("./Event.pass")).unwrap();
+
+    // Set general attributes
+    pass.pass_type_identifier("pass.nl.tudelft.ch.passes.events");
+    pass.team_identifier("F2TGZDLL7A");
+
+    // Set user specific attributes
+    pass.serial_number("1234567890");
+    pass.authentication_token("sda8f6ffDFS798SFDfsfSdf");
+
+    pass.barcode(Barcode::new(
+        BarcodeFormat::PkBarcodeFormatQr,
+        "QR Code",
+        "iso-8859-1",
+    ));
+
+    let mut store_card = Details::new();
+
+    let mut field = Field::new_f64("balance", 13.37);
+    field.label("balance");
+    field.currency_code("EUR");
+    store_card.add_primary_field(field);
+
+    let mut field = Field::new_string("account_name", "Max Mustermann");
+    field.label("account_name");
+    store_card.add_secondary_field(field);
+
+    pass.store_card(store_card);
+
+    // Sign, comprass and save pass
+    pass.export_to_file(
+        Path::new("cert.p12"),
+        "BKoP59ypG2K9",
+        Path::new("apple_wdrca.pem"),
+        Path::new("./StoreCard.pkpass"),
+    )
+    .unwrap();
+}

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -198,7 +198,7 @@ fn sign_manifest<P1: AsRef<Path>, P2: AsRef<Path>, P3: AsRef<Path>, P4: AsRef<Pa
     let mut pkcs12_buffer = Vec::new();
     pkcs12_reader.read_to_end(&mut pkcs12_buffer)?;
     let pkcs12_certificate =
-        openssl::pkcs12::Pkcs12::from_der(&pkcs12_buffer)?.parse(certificate_password)?;
+        openssl::pkcs12::Pkcs12::from_der(&pkcs12_buffer)?.parse2(certificate_password)?;
 
     let x509_file = fs::File::open(wwdr_intermediate_certificate_path)?;
     let mut x509_reader = BufReader::new(x509_file);
@@ -217,8 +217,8 @@ fn sign_manifest<P1: AsRef<Path>, P2: AsRef<Path>, P3: AsRef<Path>, P4: AsRef<Pa
     certs.push(x509_certificate)?;
 
     let signed = openssl::pkcs7::Pkcs7::sign(
-        &pkcs12_certificate.cert,
-        &pkcs12_certificate.pkey,
+        &pkcs12_certificate.cert.as_ref().unwrap(),
+        &pkcs12_certificate.pkey.as_ref().unwrap(),
         &certs,
         &manifest_buffer,
         flags,


### PR DESCRIPTION
The `parse` function in `openssl:pkcs12::Pkcs12` is depcrecated. We need to use `parse2`:

```rs
warning: use of deprecated method `openssl::pkcs12::Pkcs12Ref::parse`: Use parse2 instead
   --> src/sign.rs:201:60
    |
201 |         openssl::pkcs12::Pkcs12::from_der(&pkcs12_buffer)?.parse(certificate_password)?;
    |                                                            ^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated field `openssl::pkcs12::ParsedPkcs12::cert`: Use ParsedPkcs12_2 instead
   --> src/sign.rs:220:10
    |
220 |         &pkcs12_certificate.cert,
    |          ^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated field `openssl::pkcs12::ParsedPkcs12::pkey`: Use ParsedPkcs12_2 instead
   --> src/sign.rs:221:10
    |
221 |         &pkcs12_certificate.pkey,
    |          ^^^^^^^^^^^^^^^^^^^^^^^

warning: `wallet-pass` (lib) generated 3 warnings
```