### PR TITLE
Update parse to parse2

### DIFF
--- a/src/sign.rs
+++ b/src/sign.rs
@@ -198,7 +198,7 @@ fn sign_manifest<P1: AsRef<Path>, P2: AsRef<Path>, P3: AsRef<Path>, P4: AsRef<Pa
     let mut pkcs12_buffer = Vec::new();
     pkcs12_reader.read_to_end(&mut pkcs12_buffer)?;
     let pkcs12_certificate =
-        openssl::pkcs12::Pkcs12::from_der(&pkcs12_buffer)?.parse(certificate_password)?;
+        openssl::pkcs12::Pkcs12::from_der(&pkcs12_buffer)?.parse2(certificate_password)?;
 
     let x509_file = fs::File::open(wwdr_intermediate_certificate_path)?;
     let mut x509_reader = BufReader::new(x509_file);
@@ -217,8 +217,8 @@ fn sign_manifest<P1: AsRef<Path>, P2: AsRef<Path>, P3: AsRef<Path>, P4: AsRef<Pa
     certs.push(x509_certificate)?;
 
     let signed = openssl::pkcs7::Pkcs7::sign(
-        &pkcs12_certificate.cert,
-        &pkcs12_certificate.pkey,
+        &pkcs12_certificate.cert.as_ref().unwrap(),
+        &pkcs12_certificate.pkey.as_ref().unwrap(),
         &certs,
         &manifest_buffer,
         flags,


### PR DESCRIPTION
The `parse` function in `openssl:pkcs12::Pkcs12` is depcrecated. We need to use `parse2`:

```rs
warning: use of deprecated method `openssl::pkcs12::Pkcs12Ref::parse`: Use parse2 instead
   --> src/sign.rs:201:60
    |
201 |         openssl::pkcs12::Pkcs12::from_der(&pkcs12_buffer)?.parse(certificate_password)?;
    |                                                            ^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated field `openssl::pkcs12::ParsedPkcs12::cert`: Use ParsedPkcs12_2 instead
   --> src/sign.rs:220:10
    |
220 |         &pkcs12_certificate.cert,
    |          ^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated field `openssl::pkcs12::ParsedPkcs12::pkey`: Use ParsedPkcs12_2 instead
   --> src/sign.rs:221:10
    |
221 |         &pkcs12_certificate.pkey,
    |          ^^^^^^^^^^^^^^^^^^^^^^^

warning: `wallet-pass` (lib) generated 3 warnings
```