### PR TITLE
refactor: Add row support for auxiliaryFields

### DIFF
--- a/src/template.rs
+++ b/src/template.rs
@@ -717,6 +717,11 @@ pub struct Field {
     /// Value of the field
     #[serde(rename = "value")]
     pub value: ValueUnion,
+
+    /// Row for auxiliary fields. Set to 1 to add an extra row for auxiliary fields.
+    #[serde(rename = "row")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub row: Option<i32>,
 }
 
 impl Field {
@@ -737,6 +742,7 @@ impl Field {
             text_alignment: None,
             time_style: None,
             value: ValueUnion::String(value.into()),
+            row: None,
         }
     }
 
@@ -757,6 +763,7 @@ impl Field {
             text_alignment: None,
             time_style: None,
             value: ValueUnion::Double(value),
+            row: None,
         }
     }
 
@@ -850,6 +857,11 @@ impl Field {
     /// Style of time to display.
     pub fn time_style(&mut self, time_style: EStyle) {
         self.time_style = Some(time_style);
+    }
+
+    /// Add row information for auxiliary fields
+    pub fn row(&mut self, row: i32) {
+        self.row = Some(row);
     }
 }
 


### PR DESCRIPTION
This change aims to add `row` property to `Field` struct in order to enable `auxiliaryFields` to have 2 rows.
This [docs](https://devstreaming-cdn.apple.com/videos/wwdc/2018/720gofzcqcp431kcasf/720/720_wallet_and_apple_pay_creating_great_customer_experiences.pdf?dl=1) shows that now `auxiliaryFields` supports 2 rows, which allow developers to create better wallet passes. 